### PR TITLE
Add maskable icon purpose

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -13,14 +13,17 @@
   "icons": [{
     "src": "apple-touch-icon.png",
     "sizes": "180x180",
-    "type": "image/png"
+    "type": "image/png",
+    "purpose": "any maskable"
   },{
     "src": "android-chrome-192x192.png",
     "sizes": "192x192",
-    "type": "image/png"
+    "type": "image/png",
+    "purpose": "any maskable"
   },{
     "src": "android-chrome-512x512.png",
     "sizes": "512x512",
-    "type": "image/png"
+    "type": "image/png",
+    "purpose": "any maskable"
   }]
 }


### PR DESCRIPTION
Adding a couple lines to the web app manifest will let Android use the PokeQuest icon as [an adaptive icon](https://maskable.app/?demo=https://raw.githubusercontent.com/lukejacksonn/Malette/master/static/android-chrome-512x512.png) when the PWA is installed.